### PR TITLE
Round axis labels by Magnitude or BarUnit

### DIFF
--- a/Core40/AxisCore.cs
+++ b/Core40/AxisCore.cs
@@ -301,25 +301,12 @@ namespace LiveCharts
                     ? View.Unit
                     : 1);
 
-            if (TopLimit <= 0 && BotLimit < 0)
+            var l = Math.Round(BotLimit / m) * m;
+            FirstSeparator = l;
+            for (var i = l; i <= TopLimit - (EvaluatesUnitWidth ? u : 0); i = Math.Round((i + S) / m) * m)
             {
-                var l = TopLimit - (EvaluatesUnitWidth ? u : 0);
-                LastSeparator = l;
-                for (var i = l; i >= Math.Truncate(BotLimit / m) * m; i -= S)
-                {
-                    FirstSeparator = i;
-                    DrawSeparator(i, tolerance, currentMargin, f, source);
-                }
-            }
-            else
-            {
-                var l = Math.Truncate(BotLimit / m) * m;
-                FirstSeparator = l;
-                for (var i = l; i <= TopLimit - (EvaluatesUnitWidth ? u : 0); i += S)
-                {
-                     LastSeparator = i;
-                    DrawSeparator(i, tolerance, currentMargin, f, source);
-                }
+                LastSeparator = i;
+                DrawSeparator(i, tolerance, currentMargin, f, source);
             }
 
             return currentMargin;


### PR DESCRIPTION
#### Summary

* Separator postioning logic is changed in function LiveCharts.AxisCore.PrepareChart() of project Core40:

  * The bottom separator are always positioned first;
  * The position of bottom-most separator is caculated by rounding instead of truncation;
  * The positions of not only the bottom-most but every separator will be rounded to m (which equals to Unit or BarUnit, or Magnitude if not set);

#### Solves 

* Solves issue #918 :
  * When using truncation, values like 1.9405 (which can't be accurately represented in binary floating-point numbers) will be truncated to 1.94049, but 1.9405 is the real value people wanted.

* Solves bugs if separators comes from negative number to positive number:
  * If the data ranges from -0.15 to 0.15, the separator in the middle is placed at about 1.388E-17 but not 0. This is because -0.15+0.05+0.05+0.05 equals 1.388E-17 in binary floating-point calculations. Rounding the values should solve the problem.